### PR TITLE
fix: scanner not being compiled with rust bindings

### DIFF
--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -25,7 +25,6 @@ fn main() {
     // If your language uses an external scanner written in C++,
     // then include this block of code:
 
-    /*
     let mut cpp_config = cc::Build::new();
     cpp_config.cpp(true);
     cpp_config.include(&src_dir);
@@ -36,5 +35,4 @@ fn main() {
     cpp_config.file(&scanner_path);
     cpp_config.compile("scanner");
     println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }


### PR DESCRIPTION
Simply uncommenting the last bit of the build rs causes the rust binding to build just fine

These warnings get generated during the build process
```
warning: src/parser.c:145:17: warning: null character(s) preserved in literal
warning:   145 |   [anon_sym_] = " ",
warning:       |                 ^
warning: src/scanner.cc: In function ‘unsigned int tree_sitter_norg_external_scanner_serialize(void*, char*)’:
warning: src/scanner.cc:119:60: warning: loop variable ‘kv’ of type ‘const std::pair<char, std::vector<short unsigned int> >&’ binds to a temporary constructed from type ‘std::pair<const char, std::vector<short unsigned int> >’ [-Wrange-loop-construct]
warning:   119 |         for (const std::pair<char, std::vector<uint16_t>>& kv : scanner->indents) {
warning:       |                                                            ^~
warning: src/scanner.cc:119:60: note: use non-reference type ‘const std::pair<char, std::vector<short unsigned int> >’ to make the copy explicit or ‘const std::pair<const char, std::vector<short unsigned int> >&’ to prevent copying
```
But i doubt they're rust specific